### PR TITLE
Require subr-x

### DIFF
--- a/company-fuzzy.el
+++ b/company-fuzzy.el
@@ -35,6 +35,7 @@
 (require 'company)
 (require 'cl-lib)
 (require 's)
+(require 'subr-x)
 
 (defgroup company-fuzzy nil
   "Fuzzy matching for `company-mode'."


### PR DESCRIPTION
`string-empty-p` from `subr-x` is not loaded by default so you can a compiler warning when installing from `package.el`.